### PR TITLE
Fix table references & descriptions in vignette

### DIFF
--- a/vignettes/examples/SB10.Rmd
+++ b/vignettes/examples/SB10.Rmd
@@ -9,11 +9,11 @@ shaq <- data_frame(game = 1:23,
 
 ```
 
-Example 10 illustrates testing equality of success probablities. 
+Example 10 illustrates testing equality of success probablities. Table \ref{ex10} translates the estimating equations into the `R` function needed for `geex`:
 
 \begin{table}[H]
 \centering
-\label{ex9}
+\label{ex10}
 \caption{Translating math to code}
 \begin{tabular}{cc}
 $\psi_k(Y_i, n_i, \theta) = 

--- a/vignettes/examples/SB8.Rmd
+++ b/vignettes/examples/SB8.Rmd
@@ -11,7 +11,7 @@ dt <- data_frame(X  = rep(0:1, each = n/2),
                  id = 1:n)
 ```
 
-Example 8 illustrates robust regression. I generate a data set with `r n` observations where half of the observation have $X_i = 1$ and the others have $X_i = 0$. $Y = $ `r beta[1]` $+$ `r beta[2]` $X_i + \epsilon_i$ and $\epsilon_i \sim N(0, 1)$. Table \ref{ex8} translates the estimating equations for two sample quantiles (median and 65th percentile) into the `R` function needed for `geex`:
+Example 8 illustrates robust regression. I generate a data set with `r n` observations where half of the observation have $X_i = 1$ and the others have $X_i = 0$. $Y = $ `r beta[1]` $+$ `r beta[2]` $X_i + \epsilon_i$ and $\epsilon_i \sim N(0, 1)$. Table \ref{ex8} translates the estimating equations for robust regression into the `R` function needed for `geex`:
 
 \begin{table}[H]
 \centering

--- a/vignettes/examples/SB9.Rmd
+++ b/vignettes/examples/SB9.Rmd
@@ -11,7 +11,7 @@ dt <- data_frame(X1 = rep(0:1, each = n/2),
                  id = 1:n)
 ```
 
-Example 8 illustrates estimation of a generalized linear model. I generate a data set with `r n` observations where half of the observation have $X_{1i} = 1$ and the others have $X_{1i} = 0$. $Y_i \sim Bern[\mbox{logit}^{-1}($ `r beta[1]` $+$ `r beta[2]` $X_{1i} +$ `r beta[3]` $X_{2i})]$. Table \ref{ex9} translates the estimating equations for two sample quantiles (median and 65th percentile) into the `R` function needed for `geex`:
+Example 9 illustrates estimation of a generalized linear model. I generate a data set with `r n` observations where half of the observation have $X_{1i} = 1$ and the others have $X_{1i} = 0$. $Y_i \sim Bern[\mbox{logit}^{-1}($ `r beta[1]` $+$ `r beta[2]` $X_{1i} +$ `r beta[3]` $X_{2i})]$. Table \ref{ex9} translates the estimating equations for logistic regression into the `R` function needed for `geex`:
 
 \begin{table}[H]
 \centering


### PR DESCRIPTION
The introductory vignette had miscellaneous typos for table references and
descriptions.