### PR TITLE
allow exit after rootfinder

### DIFF
--- a/R/computations.R
+++ b/R/computations.R
@@ -150,6 +150,7 @@ estimate_equations <- function(eeFUN,
                                findroots  = TRUE,
                                roots = NULL,
                                ee_args = NULL,
+                               compute_vcov = TRUE,
                                ...){
 
   ## Warnings ##
@@ -170,6 +171,9 @@ estimate_equations <- function(eeFUN,
     theta_hat <- eesolved$root
   } else {
     theta_hat <- roots
+  }
+  if (compute_vcov == FALSE){
+    return(list(parameters = theta_hat))
   }
 
   ## Compute core matrices ##


### PR DESCRIPTION
This allows for `geex` to be used as a rootsolver; it returns only the fitted parameters, and does not go through variance calculations.

This is fairly niche issue. But it also may also prove useful.

I'm open to not providing this as a formal argument (and instead passed in through the dots `...`)