### PR TITLE
fix typo

### DIFF
--- a/vignettes/00_geex_intro.Rmd
+++ b/vignettes/00_geex_intro.Rmd
@@ -151,7 +151,7 @@ Example 2 illustrates calculation of a ratio estimator. I generate a data set wi
 
 Estimating equations:
 \[
-psi(Y_i, \theta) = 
+\psi(Y_i, \theta) = 
 \begin{pmatrix}
 Y_i - \theta_1 \\
 X_i - \theta_2 \\


### PR DESCRIPTION
I also wonder if the following SO would help? https://stackoverflow.com/questions/28505203/printing-inline-latex-equations-from-variable-in-r-trouble-with-beta

i.e. replace 

$Y \sim N$(`r mu`, `r sigma`).

with 

`r paste0("$Y \sim N(", mu, ", ", sigma ")")$`
?