### PR TITLE
exact match arguments of numDeriv::jacobian()

### DIFF
--- a/R/computations.R
+++ b/R/computations.R
@@ -147,7 +147,7 @@ compute_matrices <- function(geex_list,
   # Compute the negative of the derivative matrix of estimating eqn functions
   # (the information matrix)
   A_i <- lapply(psi_i, function(ee){
-    args <- append(list(fun = ee, x = theta), derivFUN_control)
+    args <- append(list(func = ee, x = theta), derivFUN_control)
     val  <- do.call(derivFUN, args = append(args, geex_list$inner_eeargs))
     -val
   })


### PR DESCRIPTION
In my `numDeriv` v 2016.8-1, the `jacobian()` function takes first argument `func` not `fun`. 
Unless that argument's name has changed since 2014, I think geex relies on inexact matching of arguments in the `compute_matrices` function. 

you'll also need to change the documentation related to specifying a different `derivFUN`.