### PR TITLE
update error message

### DIFF
--- a/R/m_estimate.R
+++ b/R/m_estimate.R
@@ -194,7 +194,7 @@ m_estimate <- function(estFUN,
   out@call <- call
   ## Checks/Warnings ##
   if(is.null(roots) & !compute_roots){
-    stop('If findroots = FALSE, estimates for the roots must be specified in the roots argument.')
+    stop('If compute_roots = FALSE, estimates for the roots must be specified in the roots argument.')
   }
 
   ## Compute estimating equation roots ##


### PR DESCRIPTION
Error message referred to deprecated argument name `findroots` instead of `compute_roots` in `m_estimate()`