### PR TITLE
handle groups of size 1 in grab_psiFUN's

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: geex
 Type: Package
 Title: An API for M-Estimation
-Version: 1.0.3
+Version: 1.0.4
 Authors@R: c(person("Bradley", "Saul", role = c("aut", "cre"),
                     email = "bradleysaul@gmail.com"),
              person("Brian", "Barkley", role = c("ctb")))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# geex 1.0.4
+
+* fixes issue when using `glm` objects and non-grouped data.
+
 # geex 1.0.3
 
 * adds basic examples for most functions, though to be sure, the vignettes provide more useful examples.

--- a/R/grab_psiFUN_funs.R
+++ b/R/grab_psiFUN_funs.R
@@ -95,9 +95,10 @@ grab_psiFUN.glm <- function(object, data, weights = 1, ...){
       D <- X
       V <- phi * diag(1, nrow = n, ncol = n)
     } else if(family_link == 'binomial_logit'){
-      D <- apply(X, 2, function(x) x * exp(lp)/((1+exp(lp))^2) )
+      xlp <- exp(lp)/((1+exp(lp))^2)
+      D <- apply(X, 2, function(x) x * xlp)
       # if (n==1) { D <- t(D) } ## apply will undesireably coerce to vector
-      if (is.atomic(D)) { D <- matrix(D, nrow=1) } ## apply will undesireably coerce to vector
+      if (!is.matrix(D)) { D <- matrix(D, nrow=1) } ## apply will undesireably coerce to vector
       V <- phi * diag(f * (1 - f), ncol = length(f) )/length(f)
     }
 

--- a/R/grab_psiFUN_funs.R
+++ b/R/grab_psiFUN_funs.R
@@ -138,6 +138,7 @@ grab_psiFUN.geeglm <- function(object, data, ...){
       V <- phi * diag(1, nrow = n, ncol = n)
     } else if(family_link == 'binomial_logit'){
       D <- apply(X, 2, function(x) x * exp(lp)/((1+exp(lp))^2) )
+      if (n==1) { D <- t(D) } ## apply will undesireably coerce to vector
       V <- phi * diag(f * (1 - f), ncol = length(f) )/length(f)
     }
     t(D) %*% solve(V) %*% (r)

--- a/R/grab_psiFUN_funs.R
+++ b/R/grab_psiFUN_funs.R
@@ -96,6 +96,7 @@ grab_psiFUN.glm <- function(object, data, weights = 1, ...){
       V <- phi * diag(1, nrow = n, ncol = n)
     } else if(family_link == 'binomial_logit'){
       D <- apply(X, 2, function(x) x * exp(lp)/((1+exp(lp))^2) )
+      if (n==1) { D <- t(D) } ## apply will undesireably coerce to vector
       V <- phi * diag(f * (1 - f), ncol = length(f) )/length(f)
     }
 

--- a/R/grab_psiFUN_funs.R
+++ b/R/grab_psiFUN_funs.R
@@ -96,7 +96,8 @@ grab_psiFUN.glm <- function(object, data, weights = 1, ...){
       V <- phi * diag(1, nrow = n, ncol = n)
     } else if(family_link == 'binomial_logit'){
       D <- apply(X, 2, function(x) x * exp(lp)/((1+exp(lp))^2) )
-      if (n==1) { D <- t(D) } ## apply will undesireably coerce to vector
+      # if (n==1) { D <- t(D) } ## apply will undesireably coerce to vector
+      if (is.atomic(D)) { D <- matrix(D, nrow=1) } ## apply will undesireably coerce to vector
       V <- phi * diag(f * (1 - f), ncol = length(f) )/length(f)
     }
 
@@ -138,7 +139,6 @@ grab_psiFUN.geeglm <- function(object, data, ...){
       V <- phi * diag(1, nrow = n, ncol = n)
     } else if(family_link == 'binomial_logit'){
       D <- apply(X, 2, function(x) x * exp(lp)/((1+exp(lp))^2) )
-      if (n==1) { D <- t(D) } ## apply will undesireably coerce to vector
       V <- phi * diag(f * (1 - f), ncol = length(f) )/length(f)
     }
     t(D) %*% solve(V) %*% (r)


### PR DESCRIPTION
This may not handle groups of size 1 in `grab_psiFun.mermod()` but it should be a simple workaround for the gee and glm cases.